### PR TITLE
Bump Node ECMA version to 2023

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 9.0.1 - 2023-01-26
+
+- Update ECMA version for node configurations to 2023 to match Node 18 LTS.
+
 ### 9.0.0 - 2022-06-07
 
 - Update ECMA version for all configurations to 2020

--- a/node.js
+++ b/node.js
@@ -6,7 +6,7 @@ module.exports = {
     node: true,
   },
   parserOptions: {
-    ecmaVersion: 2020
+    ecmaVersion: 2023
   },
   plugins: ["node"],
   rules: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-cesium",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "ESLint shareable configs for Cesium",
   "homepage": "http://cesium.com/",
   "license": "Apache-2.0",
@@ -19,7 +19,7 @@
     "cesium"
   ],
   "peerDependencies": {
-    "eslint": "^8",
+    "eslint": "^8.0.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-config-prettier": "^8.5.0"
   }


### PR DESCRIPTION
As per https://node.green/, Node 18 LTS supports up to ES2023. Since Cesium standardizes on the latest LTS for Node.js code, there's no reason not to make it the default.