### PR TITLE
Fix node rules in plugin/n

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 10.0.2 - 2023-12-05
+
+- Fix node configuration referring to deprecated eslint rules that were moved to `plugin/n`
+
 ### 10.0.1 - 2023-09-05
 
 - Fix bad node configuration that was still relying on `eslint-plugin-node`.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For use in browser environments.
 
 ### eslint-config-cesium/node
 
-For use in Node.js environments.
+For use in Node.js environments. Extends `plugin/n:recommended`
 
 ---
 

--- a/node.js
+++ b/node.js
@@ -10,9 +10,9 @@ module.exports = {
   },
   plugins: ["n"],
   rules: {
-    "global-require": "error",
+    "n/global-require": "error",
     "n/no-new-require": "error",
     "n/no-unsupported-features/node-builtins": "off",
-    "no-process-exit": "off",
+    "n/no-process-exit": "off",
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-cesium",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "description": "ESLint shareable configs for Cesium",
   "homepage": "http://cesium.com/",
   "license": "Apache-2.0",


### PR DESCRIPTION
I noticed that our node config was still referencing rules that are deprecated in eslint proper and moved to the `n` plugin.

I'm assuming these haven't been working as expected since the upgrade to eslint 8 so I'm not sure how much of a downstream impact they will have. Notably, 

- `global-require` is off by default, this turns it on
- `no-process-exit` is _on_ by default, this turns it off

If there have been no issues or comments against this in the past 18 months it may be worth considering removing these rules completely