### PR TITLE
Update to flat configs and eslint 9

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-    "extends": "./node.js"
-}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Change Log
 
+### 11.0.0 - 2024-04-30
+
+- Updated to [flat config files](https://eslint.org/docs/latest/use/configure/migration-guide#predefined-and-shareable-configs). `recommended`, `browser`, and `node` configurations are now accessible from the `config` object.
+- `node` configuration have been updated to the new `sourceType` `commonjs` instead of `script`.
+- Bump `eslint` peer dependency to `^9.0.0`
+- Bump `eslint-plugin-n` peer dependency to `17.0.0`
+
 ### 10.0.2 - 2023-12-05
 
 - Fix node configuration referring to deprecated eslint rules that were moved to `plugin/n`

--- a/README.md
+++ b/README.md
@@ -4,26 +4,75 @@ The official [shareable ESLint config](http://eslint.org/docs/developer-guide/sh
 
 ## Usage
 
----
-
 We export three ESLint configurations.
 
-### eslint-config-cesium
+### eslint-config-cesium default
 
-This config contains basic Cesium syntax and style config, from which `browser` and `node` extend. Extends `eslint:recommended` and `prettier` with additional rules.
+This config contains basic Cesium syntax and style config, from which `browser` and `node` extend. Extends `@eslint/js` recommended rules and `eslint-config/prettier` with additional rules.
+
+[`eslint.config.js`](https://eslint.org/docs/latest/use/configure/configuration-files)
+
+```js
+import configCesium from "eslint-config-cesium";
+
+exports default [
+    // Apply recommended rules to all files
+    configCesium.configs.recommended,
+    // Apply recommended rules to JS files with an override
+    {
+        files: ["**/*.js"],
+        rules: {
+            ...configCesium.configs.recommended.rules,
+            "no-unused-vars": "off"
+        } 
+    },
+]
+```
 
 ### eslint-config-cesium/browser
 
 For use in browser environments.
 
+[`eslint.config.js`](https://eslint.org/docs/latest/use/configure/configuration-files)
+
+```js
+import configCesium from "eslint-config-cesium";
+
+exports default [
+    // Apply recommended rules to all files
+    configCesium.configs.browser,
+    // Apply recommended rules to JS files with an override
+    {
+        files: ["**/*.js"],
+        ...configCesium.configs.browser,
+        rules: {
+            ...configCesium.configs.browser.rules,
+            "no-unused-vars": "off"
+        } 
+    },
+]
+```
+
 ### eslint-config-cesium/node
 
 For use in Node.js environments. Extends `plugin/n:recommended`
 
----
+[`eslint.config.js`](https://eslint.org/docs/latest/use/configure/configuration-files)
 
-To use any of these configs:
+```js
+import configCesium from "eslint-config-cesium";
 
-1. Install `eslint` and `eslint-config-prettier`. If using the `cesium/node` config, also install `eslint-plugin-node`.
-
-2. Add `"extends": "cesium"/browser` or `"extends": "cesium/node"` to your `.eslintrc.*` files
+exports default [
+    // Apply recommended rules to all files
+    configCesium.configs.node,
+    // Apply recommended rules to JS files with an override
+    {
+        files: ["**/*.js"],
+        ...configCesium.configs.node,
+        rules: {
+            ...configCesium.configs.node.rules,
+            "no-unused-vars": "off"
+        } 
+    },
+]
+```

--- a/browser.js
+++ b/browser.js
@@ -1,15 +1,20 @@
 "use strict";
 
+const baseConfig = require("./common.js");
+const globals = require("globals");
+
 module.exports = {
-  extends: "./index.js",
-  env: {
-    browser: true,
-  },
-  parserOptions: {
+  ...baseConfig,
+  name: "cesium/browser",
+  languageOptions: {
     sourceType: "module",
     ecmaVersion: 2020,
+    globals: {
+      ...globals.browser
+    }
   },
   rules: {
+    ...baseConfig.rules,
     "no-implicit-globals": "error",
   },
 };

--- a/common.js
+++ b/common.js
@@ -1,0 +1,46 @@
+"use strict";
+
+const js = require("@eslint/js");
+const eslintConfigPrettier = require("eslint-config-prettier");
+
+const recommended = js.configs.recommended;
+
+module.exports = {
+    ...recommended,
+    ...eslintConfigPrettier,
+    name: "cesium/recommended-",
+      rules: {
+        ...recommended.rules,
+        ...eslintConfigPrettier.rules,
+        curly: "error",
+        "block-scoped-var": "error",
+        eqeqeq: "error",
+        "guard-for-in": "error",
+        "new-cap": ["error", { properties: false }],
+        "no-alert": "error",
+        "no-caller": "error",
+        "no-console": "off",
+        "no-duplicate-imports": "error",
+        "no-else-return": "error",
+        "no-extend-native": "error",
+        "no-extra-boolean-cast": "off",
+        "no-lonely-if": "error",
+        "no-loop-func": "error",
+        "no-new": "error",
+        "no-var": "error",
+        "no-prototype-builtins": "off",
+        "no-sequences": "error",
+        "no-undef-init": "error",
+        "no-restricted-globals": ["error", "fdescribe", "fit"],
+        "no-unused-expressions": "error",
+        "no-unused-vars": ["error", { vars: "all", args: "all" }],
+        "no-useless-escape": "off",
+        "no-use-before-define": ["error", "nofunc"],
+        "prefer-const": "error",
+        "prefer-template": "error",
+        "require-atomic-updates": "off",
+        strict: "error",
+        "wrap-iife": ["error", "any"],
+      },
+  };
+  

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,4 @@
+"use strict";
+
+const nodeConfig = require("./node.js");
+module.exports = nodeConfig;

--- a/index.js
+++ b/index.js
@@ -1,39 +1,13 @@
 "use strict";
 
+const baseConfig = require("./common.js");
+const browserConfig = require("./browser.js")
+const nodeConfig = require("./node.js");
+
 module.exports = {
-  extends: ["eslint:recommended", "prettier"],
-  env: {
-    es2020: true,
-  },
-  rules: {
-    curly: "error",
-    "block-scoped-var": "error",
-    eqeqeq: "error",
-    "guard-for-in": "error",
-    "new-cap": ["error", { properties: false }],
-    "no-alert": "error",
-    "no-caller": "error",
-    "no-console": "off",
-    "no-duplicate-imports": "error",
-    "no-else-return": "error",
-    "no-extend-native": "error",
-    "no-extra-boolean-cast": "off",
-    "no-lonely-if": "error",
-    "no-loop-func": "error",
-    "no-new": "error",
-    "no-var": "error",
-    "no-prototype-builtins": "off",
-    "no-sequences": "error",
-    "no-undef-init": "error",
-    "no-restricted-globals": ["error", "fdescribe", "fit"],
-    "no-unused-expressions": "error",
-    "no-unused-vars": ["error", { vars: "all", args: "all" }],
-    "no-useless-escape": "off",
-    "no-use-before-define": ["error", "nofunc"],
-    "prefer-const": "error",
-    "prefer-template": "error",
-    "require-atomic-updates": "off",
-    strict: "error",
-    "wrap-iife": ["error", "any"],
-  },
-};
+  configs: {
+    recommended: baseConfig,
+    browser: browserConfig,
+    node: nodeConfig,
+  }
+}

--- a/node.js
+++ b/node.js
@@ -1,15 +1,21 @@
 "use strict";
 
+const nodePlugin = require("eslint-plugin-n");
+const baseConfig = require("./common.js");
+
+const cjsConfig = nodePlugin.configs["flat/recommended-script"];
+
 module.exports = {
-  extends: ["./index.js", "plugin:n/recommended"],
-  env: {
-    node: true,
-  },
-  parserOptions: {
+  ...baseConfig,
+  ...cjsConfig,
+  name: "cesium/node",
+  languageOptions: {
+    ...cjsConfig.languageOptions,
     ecmaVersion: 2023,
   },
-  plugins: ["n"],
   rules: {
+    ...baseConfig.rules,
+    ...cjsConfig.rules,
     "n/global-require": "error",
     "n/no-new-require": "error",
     "n/no-unsupported-features/node-builtins": "off",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,14 @@
     "cesium"
   ],
   "peerDependencies": {
-    "eslint": "^8.0.0",
-    "eslint-plugin-n": "^16.0.2",
-    "eslint-config-prettier": "^9.0.0"
+    "eslint": "^9.0.0",
+    "@eslint/js": "^9.0.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-n": "^17.0.0",
+    "globals": "15.0.0"
+  },
+  "type": "commonjs",
+  "engines": {
+    "node": ">=18.18.0"
   }
 }


### PR DESCRIPTION
This PR updates to the new eslint standard of [flat config files](https://eslint.org/docs/latest/use/configure/configuration-files). This is a complete breaking change in favor of the new style. Let me know if there is any need for backwards compatibility here.

* Since the `extends` property has been removed, the configs are now structured differently. The default export is now an object with a `configs` property for each type of configuration. This mirrors [`@eslint/js`](https://www.npmjs.com/package/@eslint/js), the replacement for `"eslint:recommended"`. The common rules got moved instead to `common.js` to facilitate.
* Also note `env` has been removed in favor of specifying the `sourceType` and `globals` parameters. Where not already "inherited", we now specify these properties instead.

@mramato Would you mind taking a look?
