### PR TITLE
Fix inadvertent `globals` peer dependency version of `15.0.0` instead of `^15.0.0`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 11.0.1 - 2024-05-20
+
+- Fix inadvertent `globals` peer dependency version of `15.0.0` instead of `^15.0.0`.
+
 ### 11.0.0 - 2024-04-30
 
 - Updated to [flat config files](https://eslint.org/docs/latest/use/configure/migration-guide#predefined-and-shareable-configs). `recommended`, `browser`, and `node` configurations are now accessible from the `config` object.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-cesium",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "description": "ESLint shareable configs for Cesium",
   "homepage": "http://cesium.com/",
   "license": "Apache-2.0",
@@ -23,7 +23,7 @@
     "@eslint/js": "^9.0.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-n": "^17.0.0",
-    "globals": "15.0.0"
+    "globals": "^15.0.0"
   },
   "type": "commonjs",
   "engines": {


### PR DESCRIPTION
Fix inadvertent `globals` peer dependency version of `15.0.0` instead of `^15.0.0`.